### PR TITLE
Moved auth token processing code into library

### DIFF
--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -2,7 +2,7 @@ class AuthTokensController < ApplicationController
   before_filter :authenticate!, only: [:index, :destroy]
 
   def index
-    @auth_tokens = current_user.auth_token_hash
+    @auth_tokens = AuthTokenProcessor.auth_token_hash_from(current_user)
   end
 
   def destroy
@@ -14,7 +14,7 @@ class AuthTokensController < ApplicationController
 
   def callback
     if current_user.present?
-      current_user.register_auth_token(auth_hash)
+      AuthTokenProcessor.register_auth_token(current_user, auth_hash)
       redirect_to auth_tokens_path
     else
       new_user_signup
@@ -31,7 +31,7 @@ class AuthTokensController < ApplicationController
   end
 
   def new_user_signup
-    user = User.find_or_create_from_auth_hash(auth_hash)
+    user = AuthTokenProcessor.find_or_create_user_from_auth_hash(auth_hash)
 
     if user
       session[:user_id] = user.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,49 +12,6 @@ class User < ActiveRecord::Base
     @new_user = true
   end
 
-  def self.create_from_auth_hash(auth_hash)
-    if User.exists?(email: auth_hash['info']['email'])
-      raise AuthTokenSignUpError.new("You have alreay registered an account. Login to link your #{auth_hash['provider'].titlecase} account with your TmuxMe account")
-    else
-      user = User.new(email: auth_hash['info']['email'], username: auth_hash['info']['nickname'], password: generate_random_password)
-      if user.save
-        user.register_auth_token(auth_hash)
-      else
-        raise AuthTokenSignUpError.new("Error encountered processing your #{auth_hash['provider'].titlecase} account")
-      end
-    end
-
-    return user
-  end
-
-  def register_auth_token(auth_hash)
-    auth_tokens.create(
-      uid: auth_hash['uid'],
-      provider: auth_hash['provider'],
-      info: auth_hash['info'],
-      credentials: auth_hash['credentials'],
-      extra: auth_hash['extra']
-    )
-  end
-
-  def self.find_or_create_from_auth_hash(auth_hash)
-    auth_token = AuthToken.where(uid: auth_hash['uid']).first
-    if auth_token.nil?
-      user = create_from_auth_hash(auth_hash)
-    else
-      user = auth_token.user
-    end
-
-    return user
-  end
-
-  def auth_token_hash
-    auth_tokens.inject({}) do |hsh, token|
-      hsh[token.provider] = token
-      hsh
-    end
-  end
-
   def send_password_reset_email
     self.generate_password_reset_token
     self.password_reset_sent_at = Time.zone.now
@@ -74,4 +31,3 @@ class User < ActiveRecord::Base
   end
 end
 
-class AuthTokenSignUpError < StandardError; end

--- a/lib/auth_token_processor.rb
+++ b/lib/auth_token_processor.rb
@@ -1,0 +1,46 @@
+class AuthTokenProcessor
+  def self.create_user_from_auth_hash(auth_hash)
+    if User.exists?(email: auth_hash['info']['email'])
+      raise AuthTokenSignUpError.new("You have alreay registered an account. Login to link your #{auth_hash['provider'].titlecase} account with your TmuxMe account")
+    else
+      user = User.new(email: auth_hash['info']['email'], username: auth_hash['info']['nickname'], password: User.generate_random_password)
+      if user.save
+        register_auth_token(user, auth_hash)
+      else
+        raise AuthTokenSignUpError.new("Error encountered processing your #{auth_hash['provider'].titlecase} account")
+      end
+    end
+
+    return user
+  end
+
+  def self.register_auth_token(user, auth_hash)
+    user.auth_tokens.create(
+      uid: auth_hash['uid'],
+      provider: auth_hash['provider'],
+      info: auth_hash['info'],
+      credentials: auth_hash['credentials'],
+      extra: auth_hash['extra']
+    )
+  end
+
+  def self.find_or_create_user_from_auth_hash(auth_hash)
+    auth_token = AuthToken.where(uid: auth_hash['uid']).first
+    if auth_token.nil?
+      user = create_user_from_auth_hash(auth_hash)
+    else
+      user = auth_token.user
+    end
+
+    return user
+  end
+
+  def self.auth_token_hash_from(user)
+    user.auth_tokens.inject({}) do |hsh, token|
+      hsh[token.provider] = token
+      hsh
+    end
+  end
+end
+
+class AuthTokenSignUpError < StandardError; end

--- a/spec/controllers/auth_tokens_controller_spec.rb
+++ b/spec/controllers/auth_tokens_controller_spec.rb
@@ -18,7 +18,7 @@ describe AuthTokensController do
 
       it "assigns auth tokens to @auth_tokens" do
         auth_tokens = double('auth_tokens')
-        allow(current_user).to receive(:auth_token_hash).and_return(auth_tokens)
+        allow(AuthTokenProcessor).to receive(:auth_token_hash_from).with(current_user).and_return(auth_tokens)
         get :index
         expect(assigns[:auth_tokens]).to eq(auth_tokens)
       end
@@ -66,7 +66,7 @@ describe AuthTokensController do
       before { allow(subject).to receive(:current_user).and_return(user) }
 
       it "registers the new auth token" do
-        expect(user).to receive(:register_auth_token)
+        expect(AuthTokenProcessor).to receive(:register_auth_token)
         post :callback, {provider: 'github'}
       end
 
@@ -103,13 +103,13 @@ describe AuthTokensController do
 
     it "looks up a user by auth token" do
       allow(subject).to receive(:redirect_to)
-      expect(User).to receive(:find_or_create_from_auth_hash).with(auth_hash).and_return(user)
+      expect(AuthTokenProcessor).to receive(:find_or_create_user_from_auth_hash).with(auth_hash).and_return(user)
       subject.send(:new_user_signup)
     end
 
     context "when a user is not returned" do
       before do
-        allow(User).to receive(:find_or_create_from_auth_hash).and_return(nil)
+        allow(AuthTokenProcessor).to receive(:find_or_create_user_from_auth_hash).and_return(nil)
       end
 
       it "redirects and sets an error flash message" do
@@ -120,7 +120,7 @@ describe AuthTokensController do
 
     context "when the user is returned" do
       before do
-        allow(User).to receive(:find_or_create_from_auth_hash).and_return(user)
+        allow(AuthTokenProcessor).to receive(:find_or_create_user_from_auth_hash).and_return(user)
       end
 
       it "sets the session user_id to the user id" do

--- a/spec/lib/auth_token_processor_spec.rb
+++ b/spec/lib/auth_token_processor_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+describe AuthTokenProcessor do
+  subject { AuthTokenProcessor }
+
+  describe ".create_user_from_auth_hash" do
+    let(:user) { double('user').as_null_object }
+    let(:auth_hash) { double('auth_hash').as_null_object }
+
+    context "when the user already exists" do
+      before { allow(User).to receive(:exists?).and_return(true) }
+
+      it "throws an AuthTokenSignUpError" do
+        expect { subject.create_user_from_auth_hash(auth_hash) }.to raise_error(AuthTokenSignUpError, "You have alreay registered an account. Login to link your #{auth_hash} account with your TmuxMe account")
+      end
+    end
+
+    context "when the user does not already exist" do
+      before { allow(User).to receive(:exists?).and_return(false) }
+
+      it "creates a new user from the passed hash" do
+        password = double
+        allow(User).to receive(:generate_random_password).and_return(password)
+        auth_hash = {'info' => {'nickname' => 'nickname', 'email' => 'email'}}
+        expect(User).to receive(:new).with({email: 'email', username: 'nickname', password: password}).and_return(user)
+        subject.create_user_from_auth_hash(auth_hash)
+      end
+
+      it "saves the new user" do
+        allow(User).to receive(:new).and_return(user)
+        expect(user).to receive(:save)
+        subject.create_user_from_auth_hash(auth_hash)
+      end
+
+      context "when the user is saved successfully" do
+        before do
+          allow(User).to receive(:new).and_return(user)
+          allow(user).to receive(:save).and_return(true)
+        end
+
+        it "registers a new auth token" do
+          expect(subject).to receive(:register_auth_token)
+          subject.create_user_from_auth_hash(auth_hash)
+        end
+
+        it "returns the user" do
+          expect(subject.create_user_from_auth_hash(double.as_null_object)).to eq(user)
+        end
+      end
+
+      context "when the user is not saved successfully" do
+        before do
+          allow(User).to receive(:new).and_return(user)
+          allow(user).to receive(:save).and_return(false)
+        end
+
+        it "throws an AuthTokenSignUpError" do
+          expect { subject.create_user_from_auth_hash(auth_hash) }.to raise_error(AuthTokenSignUpError, "Error encountered processing your #{auth_hash} account")
+        end
+      end
+    end
+  end
+
+  describe "#register_auth_token" do
+    it "creates a new auth token for the user" do
+      auth_tokens = double('auth_tokens')
+      user = double('user')
+      allow(user).to receive(:auth_tokens).and_return(auth_tokens)
+      expect(auth_tokens).to receive(:create)
+      subject.register_auth_token(user, double.as_null_object)
+    end
+  end
+
+  describe "#auth_token_hash_from" do
+    let(:auth_token) { double('auth_tokens', provider: 'provider') }
+
+    it "returns a hash indexed by provider" do
+      user = double('user')
+      allow(user).to receive(:auth_tokens).and_return([auth_token])
+      expect(subject.auth_token_hash_from(user)).to eq({'provider' => auth_token})
+    end
+  end
+
+  describe ".find_or_create_user_from_auth_hash" do
+    let(:auth_hash) { OmniAuth.config.mock_auth[:github] }
+    let(:user) { double('user').as_null_object }
+    let(:auth_token) { double('auth_token', user: user) }
+    let(:auth_tokens) { [auth_token] }
+
+    it "looks up a user by auth token" do
+      expect(AuthToken).to receive(:where).with(uid: '12345').and_return(auth_tokens)
+      subject.find_or_create_user_from_auth_hash(auth_hash)
+    end
+
+    context "when the auth token is found" do
+      before do
+        allow(AuthToken).to receive(:where).and_return(auth_tokens)
+      end
+
+      it "returns the user from the auth token and a logged in result message" do
+        expect(subject.find_or_create_user_from_auth_hash(auth_hash)).to eq(user)
+      end
+    end
+
+    context "when the auth token is not found" do
+      let(:new_user) { double('new_user').as_null_object }
+      before do
+        allow(AuthToken).to receive(:where).and_return([])
+      end
+
+      it "creates a new user from auth hash" do
+        expect(subject).to receive(:create_user_from_auth_hash).with(auth_hash)
+        subject.find_or_create_user_from_auth_hash(auth_hash)
+      end
+
+      it "returns the newly created user" do
+        allow(subject).to receive(:create_user_from_auth_hash).and_return(new_user)
+        expect(subject.find_or_create_user_from_auth_hash(auth_hash)).to eq(new_user)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,73 +57,6 @@ describe User do
     end
   end
 
-  describe ".create_from_auth_hash" do
-    let(:user) { double('user').as_null_object }
-    let(:auth_hash) { double('auth_hash').as_null_object }
-
-    context "when the user already exists" do
-      before { allow(User).to receive(:exists?).and_return(true) }
-
-      it "throws an AuthTokenSignUpError" do
-        expect { User.create_from_auth_hash(auth_hash) }.to raise_error(AuthTokenSignUpError, "You have alreay registered an account. Login to link your #{auth_hash} account with your TmuxMe account")
-      end
-    end
-
-    context "when the user does not already exist" do
-      before { allow(User).to receive(:exists?).and_return(false) }
-
-      it "creates a new user from the passed hash" do
-        password = double
-        allow(User).to receive(:generate_random_password).and_return(password)
-        auth_hash = {'info' => {'nickname' => 'nickname', 'email' => 'email'}}
-        expect(User).to receive(:new).with({email: 'email', username: 'nickname', password: password}).and_return(user)
-        User.create_from_auth_hash(auth_hash)
-      end
-
-      it "saves the new user" do
-        allow(User).to receive(:new).and_return(user)
-        expect(user).to receive(:save)
-        User.create_from_auth_hash(auth_hash)
-      end
-
-      context "when the user is saved successfully" do
-        before do
-          allow(User).to receive(:new).and_return(user)
-          allow(user).to receive(:save).and_return(true)
-        end
-
-        it "registers a new auth token" do
-          expect(user).to receive(:register_auth_token)
-          User.create_from_auth_hash(auth_hash)
-        end
-
-        it "returns the user" do
-          expect(User.create_from_auth_hash(double.as_null_object)).to eq(user)
-        end
-      end
-
-      context "when the user is not saved successfully" do
-        before do
-          allow(User).to receive(:new).and_return(user)
-          allow(user).to receive(:save).and_return(false)
-        end
-
-        it "throws an AuthTokenSignUpError" do
-          expect { User.create_from_auth_hash(auth_hash) }.to raise_error(AuthTokenSignUpError, "Error encountered processing your #{auth_hash} account")
-        end
-      end
-    end
-  end
-
-  describe "#register_auth_token" do
-    it "creates a new auth token for the user" do
-      auth_tokens = double('auth_tokens')
-      allow(subject).to receive(:auth_tokens).and_return(auth_tokens)
-      expect(auth_tokens).to receive(:create)
-      subject.register_auth_token(double.as_null_object)
-    end
-  end
-
   describe "#set_new_user" do
     context "when a user object is newly saved" do
       it "sets the new_user attribute to true" do
@@ -137,54 +70,6 @@ describe User do
         id = FactoryGirl.create(:user).id
         user = User.find(id)
         expect(user.new_user).to eq(nil)
-      end
-    end
-  end
-
-  describe "#auth_token_hash" do
-    let(:auth_token) { double('auth_tokens', provider: 'provider') }
-
-    it "returns a hash indexed by provider" do
-      allow(subject).to receive(:auth_tokens).and_return([auth_token])
-      expect(subject.auth_token_hash).to eq({'provider' => auth_token})
-    end
-  end
-
-  describe ".find_or_create_from_auth_hash" do
-    let(:auth_hash) { OmniAuth.config.mock_auth[:github] }
-    let(:user) { double('user').as_null_object }
-    let(:auth_token) { double('auth_token', user: user) }
-    let(:auth_tokens) { [auth_token] }
-
-    it "looks up a user by auth token" do
-      expect(AuthToken).to receive(:where).with(uid: '12345').and_return(auth_tokens)
-      User.find_or_create_from_auth_hash(auth_hash)
-    end
-
-    context "when the auth token is found" do
-      before do
-        allow(AuthToken).to receive(:where).and_return(auth_tokens)
-      end
-
-      it "returns the user from the auth token and a logged in result message" do
-        expect(User.find_or_create_from_auth_hash(auth_hash)).to eq(user)
-      end
-    end
-
-    context "when the auth token is not found" do
-      let(:new_user) { double('new_user').as_null_object }
-      before do
-        allow(AuthToken).to receive(:where).and_return([])
-      end
-
-      it "creates a new user from auth hash" do
-        expect(User).to receive(:create_from_auth_hash).with(auth_hash)
-        User.find_or_create_from_auth_hash(auth_hash)
-      end
-
-      it "returns the newly created user" do
-        allow(User).to receive(:create_from_auth_hash).and_return(new_user)
-        expect(User.find_or_create_from_auth_hash(auth_hash)).to eq(new_user)
       end
     end
   end


### PR DESCRIPTION
I did this to properly separate concerns for processing new auth tokens. The
user object had far too much knowledge of auth tokens.